### PR TITLE
Use correct flag for assertions with errcheck

### DIFF
--- a/errcheck/errcheck.go
+++ b/errcheck/errcheck.go
@@ -25,7 +25,7 @@ func (c Check) Args() []string {
 		args = append(args, "-blank")
 	}
 	if c.Assert {
-		args = append(args, "-assert")
+		args = append(args, "-asserts")
 	}
 	if c.Tags != "" {
 		args = append(args, "-tags", c.Tags)

--- a/errcheck/errcheck_test.go
+++ b/errcheck/errcheck_test.go
@@ -56,6 +56,17 @@ func TestFunc() {
 `),
 			Validate: testutil.SkippedErrors(`f\.Close`),
 		},
+		{
+			Checker: errcheck.Check{Assert: true},
+			Content: []byte(`package errchecktest
+
+func TestFunc() {
+	var i interface{} = 1
+	_ = i.(int)
+}
+`),
+			Validate: testutil.Contains("_ = i.(int)"),
+		},
 	},
 	)
 }
@@ -64,8 +75,8 @@ func TestArgs(t *testing.T) {
 	testutil.TestArgs(t, []testutil.ArgTest{
 		{A: errcheck.Check{}, Expected: nil},
 		{A: errcheck.Check{Blank: true}, Expected: []string{"-blank"}},
-		{A: errcheck.Check{Assert: true}, Expected: []string{"-assert"}},
+		{A: errcheck.Check{Assert: true}, Expected: []string{"-asserts"}},
 		{A: errcheck.Check{Tags: "test"}, Expected: []string{"-tags", "test"}},
-		{A: errcheck.Check{Blank: true, Assert: true}, Expected: []string{"-blank", "-assert"}},
+		{A: errcheck.Check{Blank: true, Assert: true}, Expected: []string{"-blank", "-asserts"}},
 	})
 }


### PR DESCRIPTION
errcheck uses the `-asserts` flag for enabling checking of assertions, but the linter passed `-assert` (without 's').